### PR TITLE
Replicator Persistent Connections Implemented

### DIFF
--- a/wal_replicator/replicator.go
+++ b/wal_replicator/replicator.go
@@ -1,0 +1,219 @@
+package wal_replicator
+
+import (
+	"log"
+	"net/rpc"
+	"sync"
+	"time"
+)
+
+// Replicator manages the push-based WAL replication from primary to followers.
+type Replicator struct {
+	logger              *log.Logger
+	nodeID              string
+	isPrimaryFunc       func() bool                       // Function to query if this node is primary
+	getPrimary          func() string                     // Function to get the current primary's address
+	getActiveNodesFunc  func() map[string]string          // Function to get active nodes from ZKManager
+	getLatestSeqNumFunc func() (uint64, error)            // Function to get latest sequence number from DB
+	getUpdatesSinceFunc func(uint64) ([]WALUpdate, error) // Function to get WAL updates from DB
+
+	// Replication state
+	followerConnections map[string]*rpc.Client // Map of follower NodeID to RPC client connection
+	followerSequence    map[string]uint64      // Map of follower NodeID to their last replicated sequence number
+
+	mu sync.RWMutex // Mutex for followerConnections and followerSequence
+
+	// Control channels
+	stopChan         chan struct{}
+	triggerReconcile chan struct{}
+}
+
+// NewReplicator creates and initializes a new Replicator instance.
+func NewReplicator(
+	logger *log.Logger,
+	nodeID string,
+	isPrimaryFunc func() bool,
+	getPrimary func() string,
+	getActiveNodesFunc func() map[string]string,
+	getLatestSeqNumFunc func() (uint64, error),
+	getUpdatesSinceFunc func(uint64) ([]WALUpdate, error),
+) *Replicator {
+	return &Replicator{
+		logger:              logger,
+		nodeID:              nodeID,
+		isPrimaryFunc:       isPrimaryFunc,
+		getPrimary:          getPrimary,
+		getActiveNodesFunc:  getActiveNodesFunc,
+		getLatestSeqNumFunc: getLatestSeqNumFunc,
+		getUpdatesSinceFunc: getUpdatesSinceFunc,
+		followerConnections: make(map[string]*rpc.Client),
+		followerSequence:    make(map[string]uint64),
+		stopChan:            make(chan struct{}),
+		triggerReconcile:    make(chan struct{}, 1), // Buffered channel to avoid blocking sender
+	}
+}
+
+// Start initiates the replication process.
+func (r *Replicator) Start() {
+	r.logger.Println("Starting WAL Replicator...")
+	go r.replicationLoop()
+	r.logger.Println("WAL Replicator started.")
+}
+
+// Stop gracefully shuts down the Replicator.
+func (r *Replicator) Stop() {
+	r.logger.Println("Stopping WAL Replicator...")
+	close(r.stopChan)
+	r.disconnectAllFollowers()
+	r.logger.Println("WAL Replicator stopped.")
+}
+
+// TriggerReconciliation can be called to signal the replicator to immediately reconcile its follower connections.
+func (r *Replicator) TriggerReconciliation() {
+	select {
+	case r.triggerReconcile <- struct{}{}:
+		r.logger.Println("Replicator reconciliation triggered.")
+	default:
+		// Already a trigger pending, no need to add another.
+		r.logger.Println("Replicator reconciliation already pending, skipping trigger.")
+	}
+}
+
+// replicationLoop is the main loop for the Replicator.
+// It continuously checks primary status and manages replication.
+func (r *Replicator) replicationLoop() {
+	ticker := time.NewTicker(5 * time.Second) // Periodically reconcile and push updates
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.stopChan:
+			r.logger.Println("Replication loop received stop signal.")
+			return
+		case <-ticker.C:
+			r.reconcileFollowerConnections()
+			r.pushWALUpdates()
+		case <-r.triggerReconcile:
+			r.logger.Println("Replication loop received reconciliation trigger.")
+			r.reconcileFollowerConnections()
+			r.pushWALUpdates()
+		}
+	}
+}
+
+// reconcileFollowerConnections establishes/removes connections based on active nodes and primary status.
+func (r *Replicator) reconcileFollowerConnections() {
+	if !r.isPrimaryFunc() {
+		r.logger.Println("Not primary, disconnecting all followers.")
+		r.disconnectAllFollowers()
+		return
+	}
+
+	r.logger.Println("Reconciling follower connections as primary...")
+	activeNodes := r.getActiveNodesFunc()
+
+	// Identify nodes that are no longer active followers
+	r.mu.Lock()
+	for followerID, conn := range r.followerConnections {
+		if _, exists := activeNodes[followerID]; !exists || followerID == r.nodeID {
+			r.logger.Printf("Disconnecting inactive or self-node follower: %s", followerID)
+			conn.Close()
+			delete(r.followerConnections, followerID)
+			delete(r.followerSequence, followerID)
+		}
+	}
+
+	// Establish connections to new active followers
+	for nodeID, addr := range activeNodes {
+		if nodeID == r.nodeID {
+			continue // Don't connect to self
+		}
+
+		if _, connected := r.followerConnections[nodeID]; !connected {
+			r.logger.Printf("Attempting to connect to new follower %s at %s...", nodeID, addr)
+			client, err := rpc.DialHTTP("tcp", addr) // Assuming RPC over HTTP
+			if err != nil {
+				r.logger.Printf("ERROR: Failed to connect to follower %s at %s: %v", nodeID, addr, err)
+				continue
+			}
+			r.followerConnections[nodeID] = client
+			// Initialize follower sequence number to 0, it will be updated on first sync
+			r.followerSequence[nodeID] = 0
+			r.logger.Printf("Successfully connected to follower %s at %s.", nodeID, addr)
+		}
+	}
+	r.mu.Unlock()
+}
+
+// disconnectAllFollowers closes all active follower RPC connections.
+func (r *Replicator) disconnectAllFollowers() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for followerID, conn := range r.followerConnections {
+		r.logger.Printf("Closing connection to follower: %s", followerID)
+		if err := conn.Close(); err != nil {
+			r.logger.Printf("ERROR: Failed to close connection to follower %s: %v", followerID, err)
+		}
+		delete(r.followerConnections, followerID)
+		delete(r.followerSequence, followerID)
+	}
+	r.logger.Println("All follower connections closed.")
+}
+
+// pushWALUpdates attempts to push WAL entries to all connected followers.
+func (r *Replicator) pushWALUpdates() {
+	if !r.isPrimaryFunc() {
+		return // Only primary pushes updates
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	latestSeqNum, err := r.getLatestSeqNumFunc()
+	if err != nil {
+		r.logger.Printf("ERROR: Failed to get latest sequence number from DB: %v", err)
+		return
+	}
+
+	for followerID, conn := range r.followerConnections {
+		go func(id string, client *rpc.Client) {
+			lastSyncedSeq := r.followerSequence[id]
+			if latestSeqNum <= lastSyncedSeq {
+				// r.logger.Printf("Follower %s is up-to-date (seq: %d)", id, lastSyncedSeq)
+				return
+			}
+
+			r.logger.Printf("Pushing updates to follower %s from sequence %d to %d", id, lastSyncedSeq, latestSeqNum)
+			updates, err := r.getUpdatesSinceFunc(lastSyncedSeq)
+			if err != nil {
+				r.logger.Printf("ERROR: Failed to get WAL updates for follower %s from DB: %v", id, err)
+				return
+			}
+
+			if len(updates) == 0 {
+				// This can happen if latestSeqNum was from a read, but no actual new writes occurred since lastSyncedSeq.
+				// Or if updates were filtered out (e.g., internal-only ops).
+				// r.logger.Printf("No new WAL updates for follower %s since sequence %d.", id, lastSyncedSeq)
+				return
+			}
+
+			// Define the RPC request and response types if needed for actual RPC calls
+			// For now, assume a simple call for placeholder.
+			var reply string // Or a more structured reply if needed
+
+			// Example: Call a remote RPC method on the follower
+			// client.Call("FollowerService.ApplyWALUpdates", updates, &reply)
+			// Replace with actual RPC call once follower RPC service is defined.
+			r.logger.Printf("INFO: Simulating push of %d updates to follower %s. (Need to implement actual RPC call).", len(updates), id)
+			_ = reply // Placeholder to avoid unused variable warning
+
+			// Update the last synced sequence number for this follower
+			r.mu.Lock()
+			r.followerSequence[id] = latestSeqNum
+			r.mu.Unlock()
+			r.logger.Printf("Successfully simulated push of updates to follower %s. New synced sequence: %d", id, latestSeqNum)
+
+		}(followerID, conn)
+	}
+}

--- a/wal_replicator/server.go
+++ b/wal_replicator/server.go
@@ -75,11 +75,9 @@ func NewWALReplicationServer(cfg WALConfig) (*WALReplicationServer, error) {
 	server.replicator = NewReplicator(
 		logger,
 		cfg.NodeID,
-		server.IsPrimary,
-		server.GetPrimary,
-		server.zkManager.GetActiveNodes,
-		server.db.GetLatestSequenceNumber,
-		server.db.GetUpdatesSince,
+		server,           // WALReplicationServer implements PrimaryChecker (IsPrimary, GetPrimary)
+		server.zkManager, // ZKManager implements NodeRegistry (GetActiveNodes)
+		server.db,        // PebbleDBStore implements WALSource (GetLatestSequenceNumber, GetUpdatesSince)
 	)
 
 	logger.Println("WALReplicationServer instance created successfully.")

--- a/wal_replicator/server.go
+++ b/wal_replicator/server.go
@@ -19,6 +19,7 @@ type WALReplicationServer struct {
 	db         *PebbleDBStore // Use the new PebbleDBStore type
 	httpServer *http.Server   // Add HTTP server instance for graceful shutdown
 	zkManager  *ZKManager     // Add ZKManager instance for ZooKeeper operations
+	replicator *Replicator    // Add Replicator instance for WAL push replication
 }
 
 // WALConfig holds configuration parameters for the WALReplicationServer.
@@ -55,12 +56,31 @@ func NewWALReplicationServer(cfg WALConfig) (*WALReplicationServer, error) {
 		db:     dbStore, // Assign the new PebbleDBStore
 	}
 
-	// Initialize ZKManager and connect
-	server.zkManager = NewZKManager(logger, cfg.NodeID) // Initialize ZKManager without connection
+	// Define the node change callback to trigger replicator reconciliation
+	nodeChangeCallback := func(activeNodes map[string]string) {
+		server.logger.Printf("Node change detected by WALReplicationServer. Triggering replicator reconciliation.")
+		if server.replicator != nil {
+			server.replicator.TriggerReconciliation()
+		}
+	}
+
+	// Initialize ZKManager and connect, passing the node change callback
+	server.zkManager = NewZKManager(logger, cfg.NodeID, nodeChangeCallback)
 	if err := server.zkManager.Connect(cfg.ZkServers); err != nil {
 		dbStore.Close() // Ensure DB is closed if ZK connection fails
 		return nil, err
 	}
+
+	// Initialize the Replicator
+	server.replicator = NewReplicator(
+		logger,
+		cfg.NodeID,
+		server.IsPrimary,
+		server.GetPrimary,
+		server.zkManager.GetActiveNodes,
+		server.db.GetLatestSequenceNumber,
+		server.db.GetUpdatesSince,
+	)
 
 	logger.Println("WALReplicationServer instance created successfully.")
 	return server, nil
@@ -77,6 +97,11 @@ func (wrs *WALReplicationServer) Start() error {
 			wrs.logger.Printf("Error starting ZKManager: %v", err)
 			return err // Fail if ZKManager cannot start properly
 		}
+	}
+
+	// Start the Replicator if initialized
+	if wrs.replicator != nil {
+		wrs.replicator.Start()
 	}
 
 	wrs.logger.Printf("WALReplicationServer node %s started successfully.", wrs.config.NodeID)
@@ -124,12 +149,15 @@ func (wrs *WALReplicationServer) Shutdown() error {
 		wrs.httpServer = nil
 	}
 
+	// Stop the Replicator
+	if wrs.replicator != nil {
+		wrs.replicator.Stop()
+	}
+
 	// Close ZooKeeper connection via ZKManager
 	if wrs.zkManager != nil {
 		wrs.zkManager.Close()
 	}
-
-	// No specific WAL internal components to shut down yet, as replication logic is not implemented.
 
 	// Close PebbleDB
 	if err := wrs.Close(); err != nil {


### PR DESCRIPTION
As part of a multi step effort to implement Push-based Replication, apply the following changes to Replicator service:
*   **Persistent Connections (Leader to Followers):**
    Establish and maintain persistent network connections from the leader to each of its registered followers. These connections will be used for pushing WAL entries.