### PR TITLE
Workflow PR Comment Fix

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,6 +35,7 @@ jobs:
             govulncheck-report.json
 
       - name: Comment on PR
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow is failing when run on main branch. Specifically the "Comment on PR" step fails with `SyntaxError: Unexpected token ','`. Update the workflow to fix this error.